### PR TITLE
When setting the RSVP status for a student on an invite, set the invite to viewed

### DIFF
--- a/src/queries/queries.service.ts
+++ b/src/queries/queries.service.ts
@@ -166,12 +166,20 @@ export class QueriesService {
       x => x.transcriptId === transcriptId,
     );
 
+    if (invite && !invite.viewedAt) {
+      const viewed = true;
+      await this.queryDataService.updateQueryInviteStatus(queryId, {
+        viewed: viewed,
+        student_address: transcriptId,
+      });
+    }
+
     if (invite && invite.attended === true) {
       throw new UserInputError(
         'Not allowed to modify the event invite after the event has been attended.',
       );
     }
-    input.viewed = true;
+
     const response = await this.queryDataService.updateQueryInviteStatus(
       queryId,
       {

--- a/src/queries/queries.service.ts
+++ b/src/queries/queries.service.ts
@@ -166,14 +166,13 @@ export class QueriesService {
       x => x.transcriptId === transcriptId,
     );
 
-    if (invite && !invite.viewedAt) {
-      await this.queryDataService.updateQueryInviteStatus(queryId, {
-        viewed: true,
-        student_address: transcriptId,
-      });
-    }
-
     if (invite && invite.attended === true) {
+      if (invite && !invite.viewedAt) {
+        await this.queryDataService.updateQueryInviteStatus(queryId, {
+          viewed: true,
+          student_address: transcriptId,
+        });
+      }
       throw new UserInputError(
         'Not allowed to modify the event invite after the event has been attended.',
       );
@@ -183,6 +182,7 @@ export class QueriesService {
       queryId,
       {
         ...input,
+        viewed: invite && !invite.viewedAt ? true : undefined,
         student_address: transcriptId,
       },
     );

--- a/src/queries/queries.service.ts
+++ b/src/queries/queries.service.ts
@@ -171,6 +171,7 @@ export class QueriesService {
         'Not allowed to modify the event invite after the event has been attended.',
       );
     }
+    input.viewed = true;
     const response = await this.queryDataService.updateQueryInviteStatus(
       queryId,
       {

--- a/src/queries/queries.service.ts
+++ b/src/queries/queries.service.ts
@@ -175,9 +175,9 @@ export class QueriesService {
     const response = await this.queryDataService.updateQueryInviteStatus(
       queryId,
       {
-        ...input,
-        viewed: invite && !invite.viewedAt ? true : undefined,
+        viewed: !!invite?.viewedAt ? undefined : true,
         student_address: transcriptId,
+        ...input,
       },
     );
     const mappedResponse = mapEventQuery(response);

--- a/src/queries/queries.service.ts
+++ b/src/queries/queries.service.ts
@@ -167,7 +167,7 @@ export class QueriesService {
     );
 
     if (invite && invite.attended === true) {
-      if (invite && !invite.viewedAt) {
+      if (!invite.viewedAt) {
         await this.queryDataService.updateQueryInviteStatus(queryId, {
           viewed: true,
           student_address: transcriptId,

--- a/src/queries/queries.service.ts
+++ b/src/queries/queries.service.ts
@@ -175,9 +175,9 @@ export class QueriesService {
     const response = await this.queryDataService.updateQueryInviteStatus(
       queryId,
       {
+        ...input,
         viewed: input.viewed ?? (!!invite?.viewedAt ? undefined : true),
         student_address: transcriptId,
-        ...input,
       },
     );
     const mappedResponse = mapEventQuery(response);

--- a/src/queries/queries.service.ts
+++ b/src/queries/queries.service.ts
@@ -167,12 +167,6 @@ export class QueriesService {
     );
 
     if (invite && invite.attended === true) {
-      if (!invite.viewedAt) {
-        await this.queryDataService.updateQueryInviteStatus(queryId, {
-          viewed: true,
-          student_address: transcriptId,
-        });
-      }
       throw new UserInputError(
         'Not allowed to modify the event invite after the event has been attended.',
       );

--- a/src/queries/queries.service.ts
+++ b/src/queries/queries.service.ts
@@ -175,7 +175,7 @@ export class QueriesService {
     const response = await this.queryDataService.updateQueryInviteStatus(
       queryId,
       {
-        viewed: !!invite?.viewedAt ? undefined : true,
+        viewed: input.viewed ?? (!!invite?.viewedAt ? undefined : true),
         student_address: transcriptId,
         ...input,
       },

--- a/src/queries/queries.service.ts
+++ b/src/queries/queries.service.ts
@@ -167,9 +167,8 @@ export class QueriesService {
     );
 
     if (invite && !invite.viewedAt) {
-      const viewed = true;
       await this.queryDataService.updateQueryInviteStatus(queryId, {
-        viewed: viewed,
+        viewed: true,
         student_address: transcriptId,
       });
     }


### PR DESCRIPTION
When setting the RSVP status for a student on an invite, set the invite to viewed if not viewed already to prevent bad state.
Task #311