### PR TITLE
fix(#326): remove redundant update invite call

### DIFF
--- a/src/queries/resolvers/event-details.resolver.ts
+++ b/src/queries/resolvers/event-details.resolver.ts
@@ -101,12 +101,7 @@ export class EventDetailsResolver {
   ): Promise<EventQuery> {
     const linkInput = { student_number: user.dbId, user_id: user.userId };
     await this.queriesService.linkStudent(queryId, user.dbId, linkInput);
-    const statusInput = { attended: true };
-    return this.queriesService.updateQueryInvite(
-      queryId,
-      user.dbId,
-      statusInput,
-    );
+    return this.queriesService.getStudentQuery(queryId, user.dbId);
   }
 
   @ResolveField('attachments', _returns => [UploadedFile])


### PR DESCRIPTION
The first call sets the attended to true when the linking happens, so no need for the second call.

see:
https://github.com/registreerocks/query-db-api/blob/389701a84b541308b58c3fe42d6ec47f90f0a5dd/package/src/swagger_server/controllers/update.py#L6-L13