### PR TITLE
Fix E2E test

### DIFF
--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -15,6 +15,10 @@ describe('AppController (e2e)', () => {
     await app.init();
   });
 
+  afterAll(async () => {
+    await app.close();
+  });
+
   it('/ (GET)', () => {
     return supertest(app.getHttpServer())
       .get('/')

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,6 +1,10 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
+  "moduleNameMapper": {
+    "^src/(.*)": "<rootDir>/src/$1"
+  },
+  "rootDir": "..",
+  "roots": ["<rootDir>/test"],
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "transform": {


### PR DESCRIPTION
This makes `yarn test:e2e` work again.

(I know we only have the "Hello, world!" E2E test, but that's still useful for integration smoke-testing, and as a foundation for future tests.)