### PR TITLE
CI: fix Yarn 2 caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,10 @@ orbs:
   codecov: codecov/codecov@1.1.2
 
 commands:
+  # The circleci/node orb doesn't support Yarn 2 natively yet.
+  #
+  # Upstream issue: https://github.com/CircleCI-Public/node-orb/issues/69
+  #
   install-packages-yarn-2:
     description: 'Install packages with Yarn 2'
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  node: circleci/node@3.0.0
+  node: circleci/node@4.1.0
   docker: circleci/docker@1.2.1
   kube-orb: circleci/kubernetes@0.11.0
   codecov: codecov/codecov@1.1.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,10 @@ commands:
           # Yarn 2 deprecates "--frozen-lockfile" in favour of "--immutable"
           override-ci-command: yarn install --immutable
 
+          # Yarn 1 default: "node_modules"
+          # Yarn 2 uses ".yarn/cache" instead
+          cache-path: .yarn/cache
+
 jobs:
   test:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,14 @@ orbs:
   kube-orb: circleci/kubernetes@0.11.0
   codecov: codecov/codecov@1.1.2
 
+commands:
+  install-packages-yarn-2:
+    description: 'Install packages with Yarn 2'
+    steps:
+      - node/install-packages:
+          pkg-manager: yarn
+          override-ci-command: yarn install --immutable
+
 jobs:
   test:
     executor:
@@ -12,9 +20,7 @@ jobs:
       tag: current
     steps:
       - checkout
-      - node/install-packages:
-          override-ci-command: yarn install --immutable
-          pkg-manager: yarn
+      - install-packages-yarn-2
       - run:
           command: yarn test:cov -w 1
       - codecov/upload:
@@ -25,9 +31,7 @@ jobs:
       tag: current
     steps:
       - checkout
-      - node/install-packages:
-          override-ci-command: yarn install --immutable
-          pkg-manager: yarn
+      - install-packages-yarn-2
       - run:
           command: yarn build
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,15 @@ commands:
           # Yarn 2 uses ".yarn/cache" instead
           cache-path: .yarn/cache
 
+          # Disable this while the orb lacks more useful partial cache keys.
+          #
+          # Upstream bug: https://github.com/CircleCI-Public/node-orb/issues/63
+          #
+          # (The current behaviour is to prefix the with the branch name,
+          # which effectively clears the cache for every new branch.)
+          #
+          include-branch-in-cache-key: false
+
 jobs:
   test:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,12 @@ commands:
   install-packages-yarn-2:
     description: 'Install packages with Yarn 2'
     steps:
+      # Reference: https://circleci.com/developer/orbs/orb/circleci/node#commands-install-packages
       - node/install-packages:
           pkg-manager: yarn
+
+          # Yarn 1 default: "yarn install --frozen-lockfile"
+          # Yarn 2 deprecates "--frozen-lockfile" in favour of "--immutable"
           override-ci-command: yarn install --immutable
 
 jobs:


### PR DESCRIPTION
This mainly fixes the package caching to work for Yarn 2, ut also cleans up the CircleCI build steps a bit (see commits and comments).

This is really something that should be fixed in the upstream `circleci/node` orb: I'll file an issue for it.

### Before

```
➤ YN0000: ┌ Fetch step
➤ YN0013: │ 7 packages were already cached, 1465 had to be fetched
➤ YN0000: └ Completed in 1m 16s
```

### After

````
➤ YN0000: ┌ Fetch step
➤ YN0013: │ 1465 packages were already cached
➤ YN0000: └ Completed in 0s 492ms
````

🎉