### PR TITLE
CI: add test-e2e job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,21 @@ jobs:
           command: yarn test:cov -w 1
       - codecov/upload:
           file: 'coverage/lcov.info'
+
+  test-e2e:
+    docker:
+      - image: cimg/node:current
+      - image: circleci/mongo
+    steps:
+      - checkout
+      - install-packages-yarn-2
+      - run:
+          command: |
+            cp .env.tests .env
+            yarn test:e2e --coverage
+      - codecov/upload:
+          file: 'coverage/lcov.info'
+
   build:
     executor:
       name: node/default
@@ -68,6 +83,7 @@ workflows:
   build-and-push:
     jobs:
       - test
+      - test-e2e
       - build
       - docker/publish:
           filters:

--- a/.env.tests
+++ b/.env.tests
@@ -1,0 +1,22 @@
+# Storage
+LOCAL_OBJECT_STORAGE=true
+S3_ENDPOINT=dummy
+S3_ACCESS_KEY_ID=dummy
+S3_SECRET=dummy
+
+# Auth config
+AUTH0_DOMAIN=registree.eu.auth0.com
+AUTH0_CLIENT_ID=dummy
+AUTH0_CLIENT_SECRET=dummy
+AUTH0_AUDIENCE=http://localhost:3000
+AUTH0_MANAGEMENT_API=https://link.to/auth0/management/api
+AUTH0_CONNECTION=dummy
+AUTH0_API_KEY=dummy
+ADMIN_API_KEY=dummy
+
+# API config
+CUSTOMER_API=http://customer-api.example.com
+QUERY_API=http://query-api.example.com
+STUDENT_API=http://student-api.example.com
+LINKING_API=http://linking-api.example.com
+IDENTIFYING_API=http://identifying-api.example.com


### PR DESCRIPTION
(Closes #353)

This adds a very straightforward `test-e2e` job alongside the existing `test` job. This doesn't really add any intentional test coverage, on its own, but at least it serves as a simple integration smoke-test, and as a base to work on.