### PR TITLE
feat: add Academic Year of Study

### DIFF
--- a/src/common/amount.union.regression.spec.ts
+++ b/src/common/amount.union.regression.spec.ts
@@ -59,6 +59,7 @@ async function withScenario(
           amount: { amountType: 'Absolute', absolute: 10 },
         },
       ],
+      academicYearOfStudyList: [],
       rawResults: [],
       updatedAt: new Date(),
     },

--- a/src/queries/dto/create-event-query.input.arb.ts
+++ b/src/queries/dto/create-event-query.input.arb.ts
@@ -1,4 +1,8 @@
 import fc from 'fast-check';
+import {
+  AcademicYearOfStudy,
+  AcademicYearOfStudyLabels,
+} from '../models/academic-year-of-study.model';
 import { CreateEventQueryInput } from './create-event-query.input';
 import {
   arbitraryDegreeInput,
@@ -18,6 +22,7 @@ export function arbitraryCreateEventQueryInput(): fc.Arbitrary<
         information: fc.string({ minLength: 1 }),
         message: fc.string(),
         degrees: fc.array(arbitraryDegreeInput()),
+        academicYearOfStudyList: fc.shuffledSubarray(academicYearOfStudyValues),
         eventType: fc.string({ minLength: 1 }),
         // TODO: attachments?
         password: fc.string(),
@@ -30,6 +35,7 @@ export function arbitraryCreateEventQueryInput(): fc.Arbitrary<
           'endDate',
           'information',
           'degrees',
+          'academicYearOfStudyList',
           'eventType',
         ],
       },
@@ -50,6 +56,16 @@ export function arbitraryInvalidCreateEventQueryInput(): fc.Arbitrary<
     fc.array(arbitraryInvalidDegreeInput(), { minLength: 1 }),
     decoys,
   );
+  const notAcademicYearOfStudyList = fc.oneof(
+    fc.array(fc.constantFrom(...academicYearOfStudyValues), {
+      minLength: academicYearOfStudyValues.length + 1, // Ensure at least one duplicate.
+    }),
+    fc
+      .anything()
+      .filter(
+        o => !(Array.isArray(o) && o.every(v => v in AcademicYearOfStudy)),
+      ),
+  );
 
   const invalidFields = {
     name: notFullString,
@@ -59,6 +75,7 @@ export function arbitraryInvalidCreateEventQueryInput(): fc.Arbitrary<
     information: notFullString,
     message: notOptionalString,
     degrees: notDegrees,
+    academicYearOfStudyList: notAcademicYearOfStudyList,
     eventType: notFullString,
     // TODO: attachments?
     password: notOptionalString,
@@ -77,3 +94,5 @@ export function arbitraryInvalidCreateEventQueryInput(): fc.Arbitrary<
     invalidRecords.map(invalid => Object.assign(valid, invalid)),
   );
 }
+
+const academicYearOfStudyValues = Array.from(AcademicYearOfStudyLabels.keys());

--- a/src/queries/dto/create-event-query.input.spec.ts
+++ b/src/queries/dto/create-event-query.input.spec.ts
@@ -23,6 +23,8 @@ describe('CreateEventQueryInput', () => {
       An instance of CreateEventQueryInput has failed the validation:
        - property degrees has failed the following constraints: isArray 
       An instance of CreateEventQueryInput has failed the validation:
+       - property academicYearOfStudyList has failed the following constraints: arrayUnique, isEnum 
+      An instance of CreateEventQueryInput has failed the validation:
        - property eventType has failed the following constraints: minLength 
       "
     `);

--- a/src/queries/dto/create-event-query.input.ts
+++ b/src/queries/dto/create-event-query.input.ts
@@ -1,9 +1,12 @@
 import { InputType, Field, GraphQLISODateTime } from '@nestjs/graphql';
 import { FileUpload, GraphQLUpload } from 'graphql-upload';
+import { AcademicYearOfStudy } from '../models/academic-year-of-study.model';
 import { DegreeInput } from './degree.input';
 import {
+  ArrayUnique,
   IsArray,
   IsDate,
+  IsEnum,
   IsOptional,
   IsString,
   MinLength,
@@ -43,6 +46,11 @@ export class CreateEventQueryInput {
   @ValidateNested()
   @Type(_of => DegreeInput)
   degrees!: DegreeInput[];
+
+  @Field(_type => [AcademicYearOfStudy])
+  @IsEnum(AcademicYearOfStudy, { each: true })
+  @ArrayUnique()
+  academicYearOfStudyList!: AcademicYearOfStudy[];
 
   // TODO: Enum or | type
   @Field()

--- a/src/queries/dto/expand-event-query.input.arb.ts
+++ b/src/queries/dto/expand-event-query.input.arb.ts
@@ -1,0 +1,68 @@
+import fc from 'fast-check';
+import {
+  AcademicYearOfStudy,
+  AcademicYearOfStudyLabels,
+} from '../models/academic-year-of-study.model';
+import {
+  arbitraryDegreeInput,
+  arbitraryInvalidDegreeInput,
+} from './degree.input.arb';
+import { ExpandEventQueryInput } from './expand-event-query.input';
+
+export function arbitraryExpandEventQueryInput(): fc.Arbitrary<
+  ExpandEventQueryInput
+> {
+  return fc
+    .record(
+      {
+        degrees: fc.array(arbitraryDegreeInput()),
+        academicYearOfStudyList: fc.shuffledSubarray(academicYearOfStudyValues),
+      },
+      {
+        requiredKeys: ['degrees', 'academicYearOfStudyList'],
+      },
+    )
+    .map(record => Object.assign(new ExpandEventQueryInput(), record));
+}
+
+export function arbitraryInvalidExpandEventQueryInput(): fc.Arbitrary<
+  ExpandEventQueryInput
+> {
+  const nullish = fc.oneof(fc.constant(undefined), fc.constant(null));
+  const decoys = fc.oneof(fc.boolean(), fc.integer(), fc.double());
+  const notDegrees = fc.oneof(
+    nullish,
+    fc.array(arbitraryInvalidDegreeInput(), { minLength: 1 }),
+    decoys,
+  );
+  const notAcademicYearOfStudyList = fc.oneof(
+    fc.array(fc.constantFrom(...academicYearOfStudyValues), {
+      minLength: academicYearOfStudyValues.length + 1, // Ensure at least one duplicate.
+    }),
+    fc
+      .anything()
+      .filter(
+        o => !(Array.isArray(o) && o.every(v => v in AcademicYearOfStudy)),
+      ),
+  );
+
+  const invalidFields = {
+    degrees: notDegrees,
+    academicYearOfStudyList: notAcademicYearOfStudyList,
+  };
+  // First, try individual invalid fields, then combinations of them.
+  const invalidRecords = fc.oneof(
+    fc.oneof(
+      ...Object.entries(invalidFields).map(([k, v]) => fc.record({ [k]: v })),
+    ),
+    fc
+      .record(invalidFields, { requiredKeys: [] })
+      .filter(o => 0 < Object.keys(o).length),
+  );
+
+  return arbitraryExpandEventQueryInput().chain(valid =>
+    invalidRecords.map(invalid => Object.assign(valid, invalid)),
+  );
+}
+
+const academicYearOfStudyValues = Array.from(AcademicYearOfStudyLabels.keys());

--- a/src/queries/dto/expand-event-query.input.spec.ts
+++ b/src/queries/dto/expand-event-query.input.spec.ts
@@ -1,0 +1,36 @@
+import fc from 'fast-check';
+import { validateToErrorMessage } from '../../common/test.helpers';
+import { ExpandEventQueryInput } from './expand-event-query.input';
+import {
+  arbitraryExpandEventQueryInput,
+  arbitraryInvalidExpandEventQueryInput,
+} from './expand-event-query.input.arb';
+
+describe('ExpandEventQueryInput', () => {
+  test('empty input fails', async () => {
+    expect(await validateToErrorMessage(new ExpandEventQueryInput()))
+      .toMatchInlineSnapshot(`
+      "An instance of ExpandEventQueryInput has failed the validation:
+       - property degrees has failed the following constraints: isArray 
+      An instance of ExpandEventQueryInput has failed the validation:
+       - property academicYearOfStudyList has failed the following constraints: arrayUnique, isEnum 
+      "
+    `);
+  });
+
+  test('arbitrary valid input', async () => {
+    await fc.assert(
+      fc.asyncProperty(arbitraryExpandEventQueryInput(), async input => {
+        expect(await validateToErrorMessage(input)).toBe('');
+      }),
+    );
+  });
+
+  test('arbitrary invalid input', async () => {
+    await fc.assert(
+      fc.asyncProperty(arbitraryInvalidExpandEventQueryInput(), async input => {
+        expect(await validateToErrorMessage(input)).not.toBe('');
+      }),
+    );
+  });
+});

--- a/src/queries/dto/expand-event-query.input.ts
+++ b/src/queries/dto/expand-event-query.input.ts
@@ -1,12 +1,19 @@
-import { InputType, Field } from '@nestjs/graphql';
-import { DegreeInput } from './degree.input';
-import { ValidateNested } from 'class-validator';
+import { Field, InputType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
+import { ArrayUnique, IsArray, IsEnum, ValidateNested } from 'class-validator';
+import { AcademicYearOfStudy } from '../models/academic-year-of-study.model';
+import { DegreeInput } from './degree.input';
 
 @InputType()
 export class ExpandEventQueryInput {
   @Field(_type => [DegreeInput])
+  @IsArray()
   @ValidateNested()
   @Type(_of => DegreeInput)
   degrees!: DegreeInput[];
+
+  @Field(_type => [AcademicYearOfStudy])
+  @IsEnum(AcademicYearOfStudy, { each: true })
+  @ArrayUnique()
+  academicYearOfStudyList!: AcademicYearOfStudy[];
 }

--- a/src/queries/mappers/map-query-details.ts
+++ b/src/queries/mappers/map-query-details.ts
@@ -1,4 +1,5 @@
 import { QueryResponse } from 'src/query-data/dto/query.response';
+import { AcademicYearOfStudy } from '../models/academic-year-of-study.model';
 import { QueryDetails } from '../models/query-details.model';
 import { mapRawResults } from './map-raw-results';
 
@@ -15,6 +16,8 @@ export const mapQueryDetails = ({
         ? { absolute: d.absolute, amountType: 'Absolute' }
         : { percentage: d.percentage, amountType: 'Percentage' },
   })),
+  // TODO(Pi,2021-03-01): Hardcode this for now, until we have real data.
+  academicYearOfStudyList: [AcademicYearOfStudy.YEAR_1],
   rawResults: mapRawResults(results, responses),
   updatedAt: new Date(timestamp),
 });

--- a/src/queries/models/academic-year-of-study.model.ts
+++ b/src/queries/models/academic-year-of-study.model.ts
@@ -1,0 +1,34 @@
+import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
+
+// XXX: Use values matching keys, to make these usable as GraphQL input variable values
+// without having to map them back to key names.
+/** Search criteria: The academic year of study a student is in. */
+export enum AcademicYearOfStudy {
+  YEAR_1 = 'YEAR_1',
+  YEAR_2 = 'YEAR_2',
+  YEAR_3_PLUS = 'YEAR_3_PLUS',
+}
+
+registerEnumType(AcademicYearOfStudy, {
+  name: 'AcademicYearOfStudy',
+  description: 'The academic year of study a student is in.',
+});
+
+/** User-facing labels for each academic year of study. */
+@ObjectType({
+  description: 'A labelled academic year of study.',
+})
+export class AcademicYearOfStudyLabel {
+  @Field(_type => AcademicYearOfStudy)
+  readonly academicYearOfStudy!: AcademicYearOfStudy;
+
+  @Field({ description: 'User-facing label for this year.' })
+  readonly label!: string;
+}
+
+/** User-facing labels for each academic year of study. */
+export const AcademicYearOfStudyLabels = new Map<AcademicYearOfStudy, string>([
+  [AcademicYearOfStudy.YEAR_1, '1st year'],
+  [AcademicYearOfStudy.YEAR_2, '2nd year'],
+  [AcademicYearOfStudy.YEAR_3_PLUS, '3rd year +'],
+]);

--- a/src/queries/models/query-details.model.ts
+++ b/src/queries/models/query-details.model.ts
@@ -1,4 +1,5 @@
 import { ObjectType, Field } from '@nestjs/graphql';
+import { AcademicYearOfStudy } from './academic-year-of-study.model';
 import { DegreeSelection } from './degree-selection.model';
 import { QueryTranscript } from './query-transcript.model';
 import { QueryTranscriptConnection } from './pagination/query-transcript-connection.model';
@@ -8,6 +9,9 @@ import { Faculty } from 'src/universities/models/faculty.model';
 export class QueryDetails {
   @Field(_type => [DegreeSelection])
   parameters!: DegreeSelection[];
+
+  @Field(_type => [AcademicYearOfStudy])
+  academicYearOfStudyList!: AcademicYearOfStudy[];
 
   rawResults!: QueryTranscript[];
 

--- a/src/queries/queries.module.ts
+++ b/src/queries/queries.module.ts
@@ -4,6 +4,7 @@ import { UploadModule } from 'src/upload/upload.module';
 import { QueryDataModule } from 'src/query-data/query-data.module';
 import { QueryDataAsyncOptions } from 'src/query-data/query-data.options';
 import { UploadAsyncOptions } from 'src/upload/upload.options';
+import { AcademicYearOfStudyResolver } from './resolvers/academic-year-of-study.resolver';
 import { EventDetailsResolver } from './resolvers/event-details.resolver';
 import { EventQueriesResolver } from './resolvers/event-queries.resolver';
 import { PricingModule } from 'src/pricing/pricing.module';
@@ -24,6 +25,7 @@ import { InvitationResolver } from './resolvers/invitation.resolver';
 @Module({
   imports: [UniversitiesModule],
   providers: [
+    AcademicYearOfStudyResolver,
     EventQueriesResolver,
     EventDetailsResolver,
     QueriesService,

--- a/src/queries/resolvers/__snapshots__/event-queries.resolver.spec.ts.snap
+++ b/src/queries/resolvers/__snapshots__/event-queries.resolver.spec.ts.snap
@@ -249,6 +249,7 @@ type Mutation {
 
 input ExpandEventQueryInput {
   degrees: [DegreeInput!]!
+  academicYearOfStudyList: [AcademicYearOfStudy!]!
 }
 "
 `;

--- a/src/queries/resolvers/__snapshots__/event-queries.resolver.spec.ts.snap
+++ b/src/queries/resolvers/__snapshots__/event-queries.resolver.spec.ts.snap
@@ -166,9 +166,17 @@ type QueryTranscriptConnection {
 
 type QueryDetails {
   parameters: [DegreeSelection!]!
+  academicYearOfStudyList: [AcademicYearOfStudy!]!
   faculties: [Faculty!]!
   results: [QueryTranscriptConnection!]!
   updatedAt: DateTime!
+}
+
+\\"\\"\\"The academic year of study a student is in.\\"\\"\\"
+enum AcademicYearOfStudy {
+  YEAR_1
+  YEAR_2
+  YEAR_3_PLUS
 }
 
 type RsvpCost {
@@ -226,13 +234,6 @@ input DegreeInput {
   degreeId: String!
   absolute: Int
   percentage: Int
-}
-
-\\"\\"\\"The academic year of study a student is in.\\"\\"\\"
-enum AcademicYearOfStudy {
-  YEAR_1
-  YEAR_2
-  YEAR_3_PLUS
 }
 
 \\"\\"\\"The \`Upload\` scalar type represents a file upload.\\"\\"\\"

--- a/src/queries/resolvers/__snapshots__/event-queries.resolver.spec.ts.snap
+++ b/src/queries/resolvers/__snapshots__/event-queries.resolver.spec.ts.snap
@@ -1,0 +1,246 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EventQueriesResolver schema snapshot 1`] = `
+"type BillingDetails {
+  addressee: String
+  city: String
+  country: String
+  email: String
+  line1: String
+  line2: String
+  province: String
+  vat: String
+  zip: String
+}
+
+type Contact {
+  email: String
+  name: String
+  userId: ID!
+  dbId: ID!
+}
+
+type Customer {
+  id: ID!
+  description: String
+  name: String!
+  billingDetails: BillingDetails!
+  contacts: [Contact!]!
+}
+
+type Degree {
+  id: ID!
+  name: String!
+  description: String!
+  faculty: Faculty!
+  level: String!
+}
+
+type GroupedDegrees {
+  name: String!
+  degrees: [Degree!]!
+}
+
+type Faculty {
+  id: ID!
+  name: String!
+  description: String!
+  university: University!
+  groupedDegrees: [GroupedDegrees!]!
+  degrees: [Degree!]!
+}
+
+type University {
+  id: ID!
+  country: String!
+  name: String!
+  physicalAddress: String!
+  shortName: String!
+  faculties: [Faculty!]!
+}
+
+type UploadedFile {
+  id: ID!
+  filename: String!
+  mimetype: String!
+  url: String!
+}
+
+type Invitation {
+  accepted: Boolean!
+  attended: Boolean!
+  respondedAt: DateTime
+  sentAt: DateTime
+  viewedAt: DateTime
+  email: String
+  invitationState: InvitationState!
+}
+
+\\"\\"\\"
+A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
+\\"\\"\\"
+scalar DateTime
+
+enum InvitationState {
+  NONE
+  VIEWED
+  RESPONDED
+  ACCEPTED
+  ATTENDED
+}
+
+type EventMetrics {
+  acceptedCount: Int!
+  attendedCount: Int!
+  respondedCount: Int!
+  viewedCount: Int!
+}
+
+type EventDetails {
+  address: String!
+  startDate: DateTime!
+  endDate: DateTime!
+  attachments: [UploadedFile!]!
+  information: String!
+  message: String
+  name: String!
+  eventType: String!
+  invites: [Invitation!]!
+  metrics: EventMetrics!
+  password: String
+}
+
+type DegreeSelection {
+  amount: Amount!
+  degree: Degree!
+}
+
+union Amount = Absolute | Percentage
+
+type Absolute {
+  absolute: Int!
+}
+
+type Percentage {
+  percentage: Int!
+}
+
+type PageInfo {
+  endCursor: String
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: String
+}
+
+type Student {
+  email: String!
+  name: String!
+  userId: ID!
+  studentNumber: ID!
+}
+
+type StudentLink {
+  id: ID!
+  student: Student
+}
+
+type QueryTranscript {
+  id: ID!
+  degreeAverage: Float!
+  degreeCompleted: Boolean!
+  latestTerm: Float!
+  degree: Degree!
+  studentLink: StudentLink!
+}
+
+type QueryTranscriptEdge {
+  cursor: String!
+  node: QueryTranscript!
+}
+
+type QueryTranscriptConnection {
+  edges: [QueryTranscriptEdge!]
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type QueryDetails {
+  parameters: [DegreeSelection!]!
+  faculties: [Faculty!]!
+  results: [QueryTranscriptConnection!]!
+  updatedAt: DateTime!
+}
+
+type RsvpCost {
+  cost: Float!
+  percent: Int!
+}
+
+type Quote {
+  numberOfStudents: Int!
+  rsvpCostBreakdown: [RsvpCost!]!
+}
+
+type EventQuery {
+  id: ID!
+  customer: Customer!
+  eventDetails: EventDetails!
+  queryDetails: QueryDetails!
+  quoteDetails: Quote!
+  currentPrice: Float!
+}
+
+type EventQueryEdge {
+  cursor: String!
+  node: EventQuery!
+}
+
+type EventQueryConnection {
+  edges: [EventQueryEdge!]
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type Query {
+  getQuote(createEventQueryInput: CreateEventQueryInput!): Quote!
+  getQueries(customerId: ID!, after: String, before: String, first: Int, last: Int): EventQueryConnection!
+  getStudentQueries(filter: StudentQueryFilter, after: String, before: String, first: Int, last: Int): EventQueryConnection!
+  getQuery(id: ID!): EventQuery!
+}
+
+input CreateEventQueryInput {
+  name: String!
+  address: String!
+  startDate: DateTime!
+  endDate: DateTime!
+  information: String!
+  message: String
+  degrees: [DegreeInput!]!
+  eventType: String!
+  attachments: [Upload!]
+  password: String
+}
+
+input DegreeInput {
+  degreeId: String!
+  absolute: Int
+  percentage: Int
+}
+
+\\"\\"\\"The \`Upload\` scalar type represents a file upload.\\"\\"\\"
+scalar Upload
+
+input StudentQueryFilter {
+  invitationState: InvitationState
+}
+
+type Mutation {
+  createQuery(createEventQueryInput: CreateEventQueryInput!): EventQuery!
+  expandQuery(expandEventQueryInput: ExpandEventQueryInput!, queryId: ID!): EventQuery!
+}
+
+input ExpandEventQueryInput {
+  degrees: [DegreeInput!]!
+}
+"
+`;

--- a/src/queries/resolvers/__snapshots__/event-queries.resolver.spec.ts.snap
+++ b/src/queries/resolvers/__snapshots__/event-queries.resolver.spec.ts.snap
@@ -216,6 +216,7 @@ input CreateEventQueryInput {
   information: String!
   message: String
   degrees: [DegreeInput!]!
+  academicYearOfStudyList: [AcademicYearOfStudy!]!
   eventType: String!
   attachments: [Upload!]
   password: String
@@ -225,6 +226,13 @@ input DegreeInput {
   degreeId: String!
   absolute: Int
   percentage: Int
+}
+
+\\"\\"\\"The academic year of study a student is in.\\"\\"\\"
+enum AcademicYearOfStudy {
+  YEAR_1
+  YEAR_2
+  YEAR_3_PLUS
 }
 
 \\"\\"\\"The \`Upload\` scalar type represents a file upload.\\"\\"\\"

--- a/src/queries/resolvers/academic-year-of-study.resolver.spec.ts
+++ b/src/queries/resolvers/academic-year-of-study.resolver.spec.ts
@@ -1,0 +1,85 @@
+import { INestApplication } from '@nestjs/common';
+import { GraphQLModule, GraphQLSchemaHost } from '@nestjs/graphql';
+import { Test, TestingModule } from '@nestjs/testing';
+import { gql } from 'apollo-server-core';
+import { GraphQLSchema, printSchema } from 'graphql';
+import { execGraphQL } from '../../common/test.helpers';
+import { AcademicYearOfStudyResolver } from './academic-year-of-study.resolver';
+
+describe('AcademicYearOfStudyResolver', () => {
+  let app: INestApplication;
+  let schema: GraphQLSchema;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [GraphQLModule.forRoot({ autoSchemaFile: true })],
+      providers: [AcademicYearOfStudyResolver],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+
+    const schemaHost: GraphQLSchemaHost = app.get(GraphQLSchemaHost);
+    schema = schemaHost.schema;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  test('getAcademicYearOfStudyLabels', async () => {
+    const query = gql`
+      query {
+        getAcademicYearOfStudyLabels {
+          academicYearOfStudy
+          label
+        }
+      }
+    `;
+    expect(await execGraphQL(schema, query)).toMatchInlineSnapshot(`
+      Object {
+        "data": Object {
+          "getAcademicYearOfStudyLabels": Array [
+            Object {
+              "academicYearOfStudy": "YEAR_1",
+              "label": "1st year",
+            },
+            Object {
+              "academicYearOfStudy": "YEAR_2",
+              "label": "2nd year",
+            },
+            Object {
+              "academicYearOfStudy": "YEAR_3_PLUS",
+              "label": "3rd year +",
+            },
+          ],
+        },
+      }
+    `);
+  });
+
+  test('schema snapshot', () => {
+    expect(printSchema(schema)).toMatchInlineSnapshot(`
+      "\\"\\"\\"A labelled academic year of study.\\"\\"\\"
+      type AcademicYearOfStudyLabel {
+        academicYearOfStudy: AcademicYearOfStudy!
+
+        \\"\\"\\"User-facing label for this year.\\"\\"\\"
+        label: String!
+      }
+
+      \\"\\"\\"The academic year of study a student is in.\\"\\"\\"
+      enum AcademicYearOfStudy {
+        YEAR_1
+        YEAR_2
+        YEAR_3_PLUS
+      }
+
+      type Query {
+        \\"\\"\\"Get academic years of study to display.\\"\\"\\"
+        getAcademicYearOfStudyLabels: [AcademicYearOfStudyLabel!]!
+      }
+      "
+    `);
+  });
+});

--- a/src/queries/resolvers/academic-year-of-study.resolver.ts
+++ b/src/queries/resolvers/academic-year-of-study.resolver.ts
@@ -1,0 +1,21 @@
+import { Query, Resolver } from '@nestjs/graphql';
+import {
+  AcademicYearOfStudyLabel,
+  AcademicYearOfStudyLabels,
+} from '../models/academic-year-of-study.model';
+
+@Resolver()
+export class AcademicYearOfStudyResolver {
+  @Query(_returns => [AcademicYearOfStudyLabel], {
+    description: 'Get academic years of study to display.',
+  })
+  getAcademicYearOfStudyLabels(): AcademicYearOfStudyLabel[] {
+    return Array.from(
+      AcademicYearOfStudyLabels,
+      ([academicYearOfStudy, label]): AcademicYearOfStudyLabel => ({
+        academicYearOfStudy,
+        label,
+      }),
+    );
+  }
+}

--- a/src/queries/resolvers/event-queries.resolver.spec.ts
+++ b/src/queries/resolvers/event-queries.resolver.spec.ts
@@ -1,0 +1,107 @@
+import { INestApplication } from '@nestjs/common';
+import { GraphQLModule, GraphQLSchemaHost } from '@nestjs/graphql';
+import { Test, TestingModule } from '@nestjs/testing';
+import { gql } from 'apollo-server-core';
+import fc from 'fast-check';
+import { GraphQLSchema, printSchema } from 'graphql';
+import {
+  coerceNullPrototypeObjects,
+  execGraphQL,
+} from '../../common/test.helpers';
+import { CustomersService } from '../../customers/customers.service';
+import { Quote } from '../../pricing/models/quote.model';
+import { RsvpCost } from '../../pricing/models/rsvp-cost.model';
+import { PricingService } from '../../pricing/pricing.service';
+import { arbitraryCreateEventQueryInput } from '../dto/create-event-query.input.arb';
+import { QueriesService } from '../queries.service';
+import { EventQueriesResolver } from './event-queries.resolver';
+
+describe('EventQueriesResolver', () => {
+  let app: INestApplication;
+  let schema: GraphQLSchema;
+  const mockQueriesService: Partial<QueriesService> = {};
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [GraphQLModule.forRoot({ autoSchemaFile: true })],
+      providers: [
+        { provide: QueriesService, useValue: mockQueriesService },
+        { provide: PricingService, useValue: null },
+        { provide: CustomersService, useValue: null },
+        EventQueriesResolver,
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+
+    const schemaHost: GraphQLSchemaHost = app.get(GraphQLSchemaHost);
+    schema = schemaHost.schema;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  afterEach(() => {
+    expect(mockQueriesService).toStrictEqual({});
+  });
+
+  test('getQuote', async () => {
+    const query = gql`
+      query getQuote($input: CreateEventQueryInput!) {
+        quote: getQuote(createEventQueryInput: $input) {
+          numberOfStudents
+          rsvpCostBreakdown {
+            cost
+            percent
+          }
+        }
+      }
+    `;
+
+    await fc.assert(
+      fc.asyncProperty(
+        arbitraryCreateEventQueryInput(),
+        arbitraryQuote(),
+        async (input, output) => {
+          try {
+            mockQueriesService.getQuote = jest
+              .fn()
+              .mockResolvedValueOnce(output);
+
+            const result = await execGraphQL(schema, query, {
+              variableValues: { input },
+            });
+            expect(coerceNullPrototypeObjects(result)).toStrictEqual({
+              data: { quote: output },
+            });
+            // Verify calls:
+            expect(mockQueriesService.getQuote).toHaveBeenCalledWith(input);
+            expect(mockQueriesService.getQuote).toHaveBeenCalledTimes(1);
+          } finally {
+            delete mockQueriesService.getQuote;
+          }
+        },
+      ),
+    );
+  });
+
+  test('schema snapshot', () => {
+    expect(printSchema(schema)).toMatchSnapshot();
+  });
+});
+
+function arbitraryRsvpCost(): fc.Arbitrary<RsvpCost> {
+  return fc.record({
+    cost: fc.double(),
+    percent: fc.integer(),
+  });
+}
+
+function arbitraryQuote(): fc.Arbitrary<Quote> {
+  return fc.record({
+    numberOfStudents: fc.integer(),
+    rsvpCostBreakdown: fc.array(arbitraryRsvpCost()),
+  });
+}

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -6,6 +6,21 @@ type Absolute {
   absolute: Int!
 }
 
+"""The academic year of study a student is in."""
+enum AcademicYearOfStudy {
+  YEAR_1
+  YEAR_2
+  YEAR_3_PLUS
+}
+
+"""A labelled academic year of study."""
+type AcademicYearOfStudyLabel {
+  academicYearOfStudy: AcademicYearOfStudy!
+
+  """User-facing label for this year."""
+  label: String!
+}
+
 union Amount = Absolute | Percentage
 
 type BillingDetails {
@@ -202,6 +217,9 @@ type Percentage {
 type Query {
   acceptedPrivacyPolicy: Boolean!
   customer: Customer!
+
+  """Get academic years of study to display."""
+  getAcademicYearOfStudyLabels: [AcademicYearOfStudyLabel!]!
   getContact: Contact!
   getCustomer(customerId: ID!): Customer!
   getCustomers(after: String, before: String, first: Int, last: Int): CustomerConnection!

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -152,6 +152,7 @@ type EventQueryEdge {
 }
 
 input ExpandEventQueryInput {
+  academicYearOfStudyList: [AcademicYearOfStudy!]!
   degrees: [DegreeInput!]!
 }
 

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -54,6 +54,7 @@ input CreateCustomerInput {
 }
 
 input CreateEventQueryInput {
+  academicYearOfStudyList: [AcademicYearOfStudy!]!
   address: String!
   attachments: [Upload!]
   degrees: [DegreeInput!]!

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -234,6 +234,7 @@ type Query {
 }
 
 type QueryDetails {
+  academicYearOfStudyList: [AcademicYearOfStudy!]!
   faculties: [Faculty!]!
   parameters: [DegreeSelection!]!
   results(after: String, before: String, filter: QueryTranscriptFilter, first: Int, last: Int): QueryTranscriptConnection!

--- a/test/queries.e2e-spec.ts
+++ b/test/queries.e2e-spec.ts
@@ -40,6 +40,7 @@ describe('queries (e2e)', () => {
       endDate: new Date(2020, 2, 20, 16),
       information: 'dummy information',
       degrees: [],
+      academicYearOfStudyList: [],
       eventType: 'dummy eventType',
     };
 
@@ -106,6 +107,7 @@ describe('queries (e2e)', () => {
         endDate: new Date(2020, 2, 20, 16),
         information: 'dummy information',
         degrees: [],
+        academicYearOfStudyList: [],
         eventType: 'dummy eventType',
       };
 

--- a/test/queries.e2e-spec.ts
+++ b/test/queries.e2e-spec.ts
@@ -5,6 +5,7 @@ import { assertDefined } from '../src/common/helpers';
 import { Quote } from '../src/pricing/models/quote.model';
 import { CreateEventQueryInput } from '../src/queries/dto/create-event-query.input';
 import { ExpandEventQueryInput } from '../src/queries/dto/expand-event-query.input';
+import { AcademicYearOfStudy } from '../src/queries/models/academic-year-of-study.model';
 import { EventQuery } from '../src/queries/models/event-query.model';
 import { Degree } from '../src/universities/models/degree.model';
 import {
@@ -124,7 +125,10 @@ describe('queries (e2e)', () => {
 
     async function runExpandQuery(
       queryId: string,
-      queryInput: ExpandEventQueryInput = { degrees: [] },
+      queryInput: ExpandEventQueryInput = {
+        degrees: [],
+        academicYearOfStudyList: [AcademicYearOfStudy.YEAR_1],
+      },
     ) {
       const expandQueryMutation = gql`
         mutation($queryInput: ExpandEventQueryInput!, $queryId: ID!) {
@@ -213,6 +217,7 @@ describe('queries (e2e)', () => {
             { degreeId: degrees[0].id, absolute: 10 },
             { degreeId: degrees[1].id, percentage: 5 },
           ],
+          academicYearOfStudyList: [AcademicYearOfStudy.YEAR_1],
         }),
       ).toMatchInlineSnapshot(`
         Object {
@@ -267,6 +272,7 @@ describe('queries (e2e)', () => {
       expect(
         await runExpandQuery(queryId, {
           degrees: [{ degreeId, absolute: 10 }],
+          academicYearOfStudyList: [AcademicYearOfStudy.YEAR_1],
         }),
       ).toMatchInlineSnapshot(`
         Object {
@@ -302,6 +308,7 @@ describe('queries (e2e)', () => {
       expect(
         await runExpandQuery(queryId, {
           degrees: [{ degreeId: degreeId, absolute: 5 }],
+          academicYearOfStudyList: [AcademicYearOfStudy.YEAR_1],
         }),
       ).toMatchInlineSnapshot(`
         Object {

--- a/test/queries.e2e-spec.ts
+++ b/test/queries.e2e-spec.ts
@@ -150,6 +150,7 @@ describe('queries (e2e)', () => {
                   description
                 }
               }
+              academicYearOfStudyList
             }
           }
         }
@@ -190,6 +191,9 @@ describe('queries (e2e)', () => {
           "data": Object {
             "expandQuery": Object {
               "queryDetails": Object {
+                "academicYearOfStudyList": Array [
+                  "YEAR_1",
+                ],
                 "parameters": Array [],
               },
             },
@@ -224,6 +228,9 @@ describe('queries (e2e)', () => {
           "data": Object {
             "expandQuery": Object {
               "queryDetails": Object {
+                "academicYearOfStudyList": Array [
+                  "YEAR_1",
+                ],
                 "parameters": Array [
                   Object {
                     "amount": Object {
@@ -279,6 +286,9 @@ describe('queries (e2e)', () => {
           "data": Object {
             "expandQuery": Object {
               "queryDetails": Object {
+                "academicYearOfStudyList": Array [
+                  "YEAR_1",
+                ],
                 "parameters": Array [
                   Object {
                     "amount": Object {


### PR DESCRIPTION
Closes #355

Tasks from issue:

- [x] `createQuery`, `expandQuery` and `getQuote` should accept a list of the academic year of study enum instances
- [x] Create a query that returns all of the enum values, as well as user facing metadata.

Deferred:

- ~For `expandQuery` buckets can only be added, and never be removed~ (deferred until we implement the real functionality)
