### PR TITLE
test: helpers for GraphQL

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,13 @@ module.exports = {
     jest: true,
   },
   rules: {
-    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+      },
+    ],
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     'no-console': 'error',

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "eslint": "7.10.0",
     "eslint-config-prettier": "^6.12.0",
     "eslint-plugin-import": "^2.22.1",
+    "fast-check": "^2.12.1",
     "husky": "^4.3.0",
     "jest": "26.5.2",
     "lint-staged": "^10.4.0",

--- a/src/common/test.helpers.spec.ts
+++ b/src/common/test.helpers.spec.ts
@@ -160,8 +160,11 @@ describe('execGraphQL', () => {
         dummyValue @include(if: $dummyVar)
       }
     `;
-    expect(await execGraphQL(schema, query, { dummyVar: true }))
-      .toMatchInlineSnapshot(`
+    expect(
+      await execGraphQL(schema, query, {
+        variableValues: { dummyVar: true },
+      }),
+    ).toMatchInlineSnapshot(`
       Object {
         "data": Object {
           "dummyValue": "dummy value",

--- a/src/common/test.helpers.spec.ts
+++ b/src/common/test.helpers.spec.ts
@@ -1,0 +1,95 @@
+import { gql } from 'apollo-server-core';
+import * as graphql from 'graphql';
+import { execGraphQL } from './test.helpers';
+
+describe('execGraphQL', () => {
+  let schema: graphql.GraphQLSchema;
+
+  beforeAll(() => {
+    schema = new graphql.GraphQLSchema({
+      query: new graphql.GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          dummyValue: {
+            type: graphql.GraphQLString,
+            resolve: () => 'dummy value',
+          },
+          dummyError: {
+            type: graphql.GraphQLString,
+            resolve: () => {
+              throw new Error('Dummy error');
+            },
+          },
+        },
+      }),
+    });
+  });
+
+  test('dummy value', async () => {
+    const query = gql`
+      {
+        dummyValue
+      }
+    `;
+    expect(await execGraphQL(schema, query)).toMatchInlineSnapshot(`
+      Object {
+        "data": Object {
+          "dummyValue": "dummy value",
+        },
+      }
+    `);
+  });
+
+  test('dummy error', async () => {
+    const query = gql`
+      {
+        dummyError
+      }
+    `;
+    await expect(
+      execGraphQL(schema, query),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`"Dummy error"`);
+  });
+
+  test('multiple errors', async () => {
+    const query = gql`
+      {
+        ham
+        spam
+      }
+    `;
+    await expect(execGraphQL(schema, query)).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+            "execGraphQL: Multiple errors:
+
+            Cannot query field \\"ham\\" on type \\"Query\\".
+
+            GraphQL request:3:9
+            2 |       {
+            3 |         ham
+              |         ^
+            4 |         spam
+
+            Cannot query field \\"spam\\" on type \\"Query\\".
+
+            GraphQL request:4:9
+            3 |         ham
+            4 |         spam
+              |         ^
+            5 |       }"
+          `);
+  });
+
+  test('missing query source', async () => {
+    const { loc: _, ...queryWithoutLoc } = gql`
+      {
+        dummyValue
+      }
+    `;
+    await expect(
+      execGraphQL(schema, queryWithoutLoc),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"execGraphQL: query.loc undefined"`,
+    );
+  });
+});

--- a/src/common/test.helpers.spec.ts
+++ b/src/common/test.helpers.spec.ts
@@ -40,6 +40,22 @@ describe('execGraphQL', () => {
     `);
   });
 
+  test('dummy value with variable', async () => {
+    const query = gql`
+      query dummyQuery($dummyVar: Boolean!) {
+        dummyValue @include(if: $dummyVar)
+      }
+    `;
+    expect(await execGraphQL(schema, query, { dummyVar: true }))
+      .toMatchInlineSnapshot(`
+      Object {
+        "data": Object {
+          "dummyValue": "dummy value",
+        },
+      }
+    `);
+  });
+
   test('dummy error', async () => {
     const query = gql`
       {

--- a/src/common/test.helpers.spec.ts
+++ b/src/common/test.helpers.spec.ts
@@ -154,6 +154,21 @@ describe('execGraphQL', () => {
     `);
   });
 
+  test('string query source also works', async () => {
+    const query = `
+      {
+        dummyValue
+      }
+    `;
+    expect(await execGraphQL(schema, query)).toMatchInlineSnapshot(`
+      Object {
+        "data": Object {
+          "dummyValue": "dummy value",
+        },
+      }
+    `);
+  });
+
   test('dummy value with variable', async () => {
     const query = gql`
       query dummyQuery($dummyVar: Boolean!) {
@@ -222,7 +237,7 @@ describe('execGraphQL', () => {
     await expect(
       execGraphQL(schema, queryWithoutLoc),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"execGraphQL: query.loc undefined"`,
+      `"execGraphQL: DocumentNode query has no loc"`,
     );
   });
 });

--- a/src/common/test.helpers.ts
+++ b/src/common/test.helpers.ts
@@ -20,6 +20,7 @@ import {
  *
  * @param schema Should be the result of `app.get(GraphQLSchemaHost).schema`
  * @param query Should be the result of a {@link gql} template literal.
+ * @param variableValues Optional variable values.
  *
  * @throws any underlying execution result error(s)
  *
@@ -28,6 +29,7 @@ import {
 export async function execGraphQL(
   schema: GraphQLSchema,
   query: DocumentNode,
+  variableValues?: { [key: string]: unknown } | undefined,
 ): Promise<ExecutionResult> {
   // Get the query source.
   if (query.loc === undefined) {
@@ -36,7 +38,11 @@ export async function execGraphQL(
   const source: string = query.loc.source.body;
 
   // Throw error(s), if any.
-  const result: ExecutionResult = await graphql(schema, source);
+  const result: ExecutionResult = await graphql({
+    schema,
+    source,
+    variableValues,
+  });
   if (result.errors) {
     const errors: ReadonlyArray<GraphQLError> = result.errors;
     if (errors.length === 0) {

--- a/src/common/test.helpers.ts
+++ b/src/common/test.helpers.ts
@@ -8,6 +8,7 @@ import {
   DocumentNode,
   ExecutionResult,
   graphql,
+  GraphQLArgs,
   GraphQLError,
   GraphQLSchema,
   printError,
@@ -70,7 +71,7 @@ export function coerceNullPrototypeObjects(o: unknown): unknown {
  *
  * @param schema Should be the result of `app.get(GraphQLSchemaHost).schema`
  * @param query Should be the result of a {@link gql} template literal.
- * @param variableValues Optional variable values.
+ * @param args Same as {@link graphql}
  *
  * @throws any underlying execution result error(s)
  *
@@ -79,7 +80,7 @@ export function coerceNullPrototypeObjects(o: unknown): unknown {
 export async function execGraphQL(
   schema: GraphQLSchema,
   query: DocumentNode,
-  variableValues?: { [key: string]: unknown } | undefined,
+  args?: Omit<GraphQLArgs, 'schema' | 'source'>,
 ): Promise<ExecutionResult> {
   // Get the query source.
   if (query.loc === undefined) {
@@ -87,12 +88,9 @@ export async function execGraphQL(
   }
   const source: string = query.loc.source.body;
 
+  const result: ExecutionResult = await graphql({ schema, source, ...args });
+
   // Throw error(s), if any.
-  const result: ExecutionResult = await graphql({
-    schema,
-    source,
-    variableValues,
-  });
   if (result.errors) {
     const errors: ReadonlyArray<GraphQLError> = result.errors;
     if (errors.length === 0) {

--- a/src/common/test.helpers.ts
+++ b/src/common/test.helpers.ts
@@ -3,6 +3,7 @@
  */
 
 import { gql } from 'apollo-server-core'; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { validate, ValidationError } from 'class-validator';
 import {
   DocumentNode,
   ExecutionResult,
@@ -11,6 +12,15 @@ import {
   GraphQLSchema,
   printError,
 } from 'graphql';
+
+/** Wrap {@link validate} to return any validation errors as an error message string. */
+// Suppress warning: "Object" matches the type of class-validator's validate()
+// eslint-disable-next-line @typescript-eslint/ban-types
+export async function validateToErrorMessage(object: Object): Promise<string> {
+  return (await validate(object))
+    .map((e: ValidationError) => e.toString())
+    .join('');
+}
 
 /** True for objects with the given prototype. */
 const hasPrototype = (o, prototype): o is InstanceType<typeof prototype> =>

--- a/src/common/test.helpers.ts
+++ b/src/common/test.helpers.ts
@@ -1,0 +1,57 @@
+/**
+ * Common helper code for tests.
+ */
+
+import { gql } from 'apollo-server-core'; // eslint-disable-line @typescript-eslint/no-unused-vars
+import {
+  DocumentNode,
+  ExecutionResult,
+  graphql,
+  GraphQLError,
+  GraphQLSchema,
+  printError,
+} from 'graphql';
+
+/**
+ * Like {@link graphql }, but accept a {@link DocumentNode DocumentNode} as query,
+ * and throw on error.
+ *
+ * This should provide tests with a nicer interface for testing GraphQL queries.
+ *
+ * @param schema Should be the result of `app.get(GraphQLSchemaHost).schema`
+ * @param query Should be the result of a {@link gql} template literal.
+ *
+ * @throws any underlying execution result error(s)
+ *
+ * @see https://docs.nestjs.com/graphql/quick-start#accessing-generated-schema
+ */
+export async function execGraphQL(
+  schema: GraphQLSchema,
+  query: DocumentNode,
+): Promise<ExecutionResult> {
+  // Get the query source.
+  if (query.loc === undefined) {
+    throw new TypeError('execGraphQL: query.loc undefined');
+  }
+  const source: string = query.loc.source.body;
+
+  // Throw error(s), if any.
+  const result: ExecutionResult = await graphql(schema, source);
+  if (result.errors) {
+    const errors: ReadonlyArray<GraphQLError> = result.errors;
+    if (errors.length === 0) {
+      /* istanbul ignore next: This shouldn't happen unless graphql() breaks. */
+      throw TypeError('execGraphQL: empty result.errors');
+    } else if (errors.length === 1) {
+      const [err] = errors;
+      throw err;
+    } else {
+      const message: string = ['execGraphQL: Multiple errors:']
+        .concat(errors.map(printError))
+        .join('\n\n');
+      throw Error(message);
+    }
+  }
+
+  return result;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6484,6 +6484,15 @@ class-transformer@^0.3.1:
   languageName: node
   linkType: hard
 
+"fast-check@npm:^2.12.1":
+  version: 2.12.1
+  resolution: "fast-check@npm:2.12.1"
+  dependencies:
+    pure-rand: ^4.1.1
+  checksum: 72df3b4244696efa336bef2ccb79510a4ea0f97528947f348409dae254e47e1bd09ed3cc7a77d990fc1202d5fd754a7866f24269caa0b2259dcecf9179277e69
+  languageName: node
+  linkType: hard
+
 "fast-deep-equal@npm:^3.1.1":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
@@ -11461,6 +11470,13 @@ nestjs-graphql-dataloader@^0.1.28:
   languageName: node
   linkType: hard
 
+"pure-rand@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "pure-rand@npm:4.1.1"
+  checksum: ee58642600299f2db55d8f4cd14b04df9e6dcfca764c9057909c78f0d0a20b20a33999920d008d6319c57563abfc6884485c5adc0b794547f7da2ce9283d6927
+  languageName: node
+  linkType: hard
+
 "q@npm:^1.5.1":
   version: 1.5.1
   resolution: "q@npm:1.5.1"
@@ -11762,6 +11778,7 @@ nestjs-graphql-dataloader@^0.1.28:
     eslint: 7.10.0
     eslint-config-prettier: ^6.12.0
     eslint-plugin-import: ^2.22.1
+    fast-check: ^2.12.1
     graphql: ^15.3.0
     graphql-middleware: ^4.0.2
     graphql-relay: ^0.6.0


### PR DESCRIPTION
Blocks #363

This adds two test helpers split out from the work in #363:

* `coerceNullPrototypeObjects`
* `execGraphQL`

The implementations are finicky, so these come with tests themselves, but they should allow writing simpler and better GraphQL tests in general.