### PR TITLE
chore(dependabot): disable npm ecosystem for now, pending Yarn 2 support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
       - 'sabinebertram'
     assignees:
       - 'longtomjr'
+    # Disable for now, pending Yarn 2 support.
+    # Upstream issue: https://github.com/dependabot/dependabot-core/issues/1297
+    open-pull-requests-limit: 0
 
   - package-ecosystem: 'docker'
     directory: '/'


### PR DESCRIPTION
Upstream issue:
https://github.com/dependabot/dependabot-core/issues/1297