### PR TITLE
fix: GraphQL union type resolving

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@types/supertest": "^2.0.10",
     "@typescript-eslint/eslint-plugin": "4.4.0",
     "@typescript-eslint/parser": "4.4.0",
+    "apollo-server-testing": "npm:^2.19.2",
     "eslint": "7.10.0",
     "eslint-config-prettier": "^6.12.0",
     "eslint-plugin-import": "^2.22.1",

--- a/src/common/amount.union.regression.spec.ts
+++ b/src/common/amount.union.regression.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * Regression test for a bug in @nestjs/graphql's union type resolving.
+ *
+ * The bug gets triggered after applying a schema transform (and potentially anything
+ * else that results in more than one instance of the union type objects existing).
+ *
+ * The type resolving code in @nestjs/graphql fails to normalise these to the same
+ * type instances, which causes inline type condition fragments on the union types
+ * to mismatch, and fail to return their member fields.
+ *
+ * The workaround for now is to return a string reference instead of a type instance in
+ * {@link AmountUnion#resolveType}.
+ *
+ * @see https://github.com/graphql/graphql-js/issues/1093 graphql-js #1093 (extendSchema breaks resolution of fragments on interfaces / unions)
+ * @see https://github.com/MichalLytek/type-graphql/issues/583 type-graphql #583 (Union type doesn't work when running two schemas together)
+ * @see https://github.com/MichalLytek/type-graphql/issues/605 type-graphql #605 (Reference mismatch for resolveType with classes)
+ *
+ * @see https://github.com/registreerocks/registree-core/issues/367 registree-core 367 (Check GraphQL return result on the percentage/absolute discriminated union)
+ */
+
+import {
+  getApolloServer,
+  GqlModuleOptions,
+  GraphQLModule,
+} from '@nestjs/graphql';
+import { Test, TestingModule } from '@nestjs/testing';
+import { gql } from 'apollo-server-core';
+import {
+  ApolloServerTestClient,
+  createTestClient,
+} from 'apollo-server-testing';
+import { applyMiddleware } from 'graphql-middleware';
+import { shield } from 'graphql-shield';
+import { CustomersService } from '../customers/customers.service';
+import { PricingService } from '../pricing/pricing.service';
+import { EventQuery } from '../queries/models/event-query.model';
+import { QueriesService } from '../queries/queries.service';
+import { EventQueriesResolver } from '../queries/resolvers/event-queries.resolver';
+
+/**
+ * Test helper:
+ * Set up a test scenario with the given {@link GraphQLModule} options and run `body`.
+ *
+ * This provides a mock {@link QueriesService#getQuery} result.
+ */
+async function withScenario(
+  gqlModuleOptions: GqlModuleOptions,
+  body: (client: ApolloServerTestClient) => Promise<void>,
+): Promise<void> {
+  const mockResult: Pick<EventQuery, 'queryDetails'> = {
+    queryDetails: {
+      parameters: [
+        {
+          degreeId: 'p',
+          amount: { amountType: 'Percentage', percentage: 50 },
+        },
+        {
+          degreeId: 'a',
+          amount: { amountType: 'Absolute', absolute: 10 },
+        },
+      ],
+      rawResults: [],
+      updatedAt: new Date(),
+    },
+  };
+  const mockQueriesService: Partial<QueriesService> = {
+    getQuery: jest.fn().mockResolvedValue(mockResult),
+  };
+
+  const module: TestingModule = await Test.createTestingModule({
+    imports: [GraphQLModule.forRoot(gqlModuleOptions)],
+    providers: [
+      { provide: QueriesService, useValue: mockQueriesService },
+      { provide: PricingService, useValue: null },
+      { provide: CustomersService, useValue: null },
+      EventQueriesResolver,
+    ],
+  }).compile();
+
+  const app = module.createNestApplication();
+  await app.init();
+  const client = createTestClient(getApolloServer(app));
+
+  try {
+    await body(client);
+  } finally {
+    await app.close();
+  }
+}
+
+/**
+ * Test helper:
+ * Run the test query with the given client.
+ *
+ * The intent is to confirm that the `absolute` and `percentage` fields are present.
+ */
+async function runTest(client: ApolloServerTestClient) {
+  const query = gql`
+    query getQuery($id: ID!) {
+      queryResult: getQuery(id: $id) {
+        queryDetails {
+          parameters {
+            amount {
+              __typename
+              ... on Absolute {
+                absolute
+              }
+              ... on Percentage {
+                percentage
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+  const result = await client.query({
+    query,
+    variables: { id: 'dummy-id' },
+  });
+
+  expect(result.data).toEqual({
+    queryResult: {
+      queryDetails: {
+        parameters: [
+          {
+            amount: {
+              __typename: 'Percentage',
+              percentage: 50,
+            },
+          },
+          {
+            amount: {
+              __typename: 'Absolute',
+              absolute: 10,
+            },
+          },
+        ],
+      },
+    },
+  });
+}
+
+describe('regression test for @nestjs/graphql union type resolving bug', () => {
+  const baseOptions: GqlModuleOptions = { autoSchemaFile: true };
+
+  /** Base case: this should always work. */
+  test('without schema transform', async () => {
+    await withScenario(baseOptions, async client => {
+      await runTest(client);
+    });
+  });
+
+  /** Regression case: this fails without the workaround. */
+  test('with schema transform', async () => {
+    const optionsWithMiddleware: GqlModuleOptions = {
+      ...baseOptions,
+      transformSchema: schema => applyMiddleware(schema, shield({})),
+    };
+    await withScenario(optionsWithMiddleware, async client => {
+      await runTest(client);
+    });
+  });
+});

--- a/src/common/amount.union.ts
+++ b/src/common/amount.union.ts
@@ -6,11 +6,14 @@ export const AmountUnion = createUnionType({
   name: 'Amount',
   types: () => [Absolute, Percentage],
   resolveType(value) {
+    // XXX: Return string references instead of type instances, to work around upstream
+    //      @nestjs/graphql bug.
+    // See: https://github.com/registreerocks/registree-core/issues/367
     if ((value as Absolute).absolute) {
-      return Absolute;
+      return 'Absolute';
     }
     if ((value as Percentage).percentage) {
-      return Percentage;
+      return 'Percentage';
     }
     return null;
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2264,13 +2264,13 @@ __metadata:
   linkType: hard
 
 "@types/express-serve-static-core@npm:*, @types/express-serve-static-core@npm:4.17.17":
-  version: 4.17.17
-  resolution: "@types/express-serve-static-core@npm:4.17.17"
+  version: 4.17.18
+  resolution: "@types/express-serve-static-core@npm:4.17.18"
   dependencies:
     "@types/node": "*"
     "@types/qs": "*"
     "@types/range-parser": "*"
-  checksum: 97a4f64b6153503146ff8a689d0647d2cbb5ea316bdf3844e799330591b8cde848f7f51dfe202d1cb7a4fffdd2e22b488b486215f8f51e486700e03995407c23
+  checksum: 329d5ded5c6b77c40bbed136ddf34f6fbae1ec3c43dadb5309fa60cedc3de9508a78fcba756c54e0d6362127d29b114afe4fcc75dc42a44909d48a7114315dc4
   languageName: node
   linkType: hard
 
@@ -2283,7 +2283,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/express@npm:*, @types/express@npm:4.17.8":
+"@types/express@npm:*, @types/express@npm:4.17.7, @types/express@npm:4.17.8":
   version: 4.17.8
   resolution: "@types/express@npm:4.17.8"
   dependencies:
@@ -2292,18 +2292,6 @@ __metadata:
     "@types/qs": "*"
     "@types/serve-static": "*"
   checksum: 9220ef3cb010faea3f77f85453b0ef3bd41e70003ac7d0ea2b7611ac9c36184995256cc61a7bb205f80a3bc51006cf7ccb29a0186c0d1fe0c0582946a0e65e7a
-  languageName: node
-  linkType: hard
-
-"@types/express@npm:4.17.7":
-  version: 4.17.7
-  resolution: "@types/express@npm:4.17.7"
-  dependencies:
-    "@types/body-parser": "*"
-    "@types/express-serve-static-core": "*"
-    "@types/qs": "*"
-    "@types/serve-static": "*"
-  checksum: 99b795c60e7368b575794574c35d0ffd0d119c52bc681af6beda2fee70aada78e8aef07fc0db3b88f594d5d935847de4187561d2456760eeb4fde5d10dbb3780
   languageName: node
   linkType: hard
 
@@ -3538,7 +3526,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-server-testing@npm:^2.16.1":
+"apollo-server-testing@npm:^2.16.1, apollo-server-testing@npm:^2.19.2":
   version: 2.19.2
   resolution: "apollo-server-testing@npm:2.19.2"
   dependencies:
@@ -11747,6 +11735,7 @@ nestjs-graphql-dataloader@^0.1.28:
     "@typescript-eslint/parser": 4.4.0
     apollo-server-core: ^2.19.2
     apollo-server-express: ^2.19.2
+    apollo-server-testing: "npm:^2.19.2"
     aws-sdk: ^2.770.0
     axios: ^0.20.0
     class-transformer: "patch:class-transformer@^0.3.1#./skip-promises-class-transformer.diff"


### PR DESCRIPTION
This adds a regression test and workaround for the @nestjs/graphql bug.

Closes #367 