### PR TITLE
Refactor module import config

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
       "ts"
     ],
     "rootDir": "src",
-    "testRegex": ".spec.ts$",
+    "testRegex": "\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^6.6.3",
+    "src": "link:src",
     "transliteration": "^2.1.11"
   },
   "devDependencies": {
@@ -121,9 +122,6 @@
     ],
     "rootDir": "src",
     "testRegex": ".spec.ts$",
-    "moduleNameMapper": {
-      "^src/(.*)": "<rootDir>/$1"
-    },
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },

--- a/package.json
+++ b/package.json
@@ -120,12 +120,16 @@
       "json",
       "ts"
     ],
-    "rootDir": "src",
+    "rootDir": ".",
+    "roots": [
+      "<rootDir>/src",
+      "<rootDir>/test"
+    ],
     "testRegex": "\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
-    "coverageDirectory": "../coverage",
+    "coverageDirectory": "coverage",
     "coveragePathIgnorePatterns": [
       "src/app-config/*"
     ],

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -3,7 +3,7 @@
   "rootDir": "..",
   "roots": ["<rootDir>/test"],
   "testEnvironment": "node",
-  "testRegex": ".e2e-spec.ts$",
+  "testRegex": "\\.e2e-spec\\.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   }

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,8 +1,5 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
-  "moduleNameMapper": {
-    "^src/(.*)": "<rootDir>/src/$1"
-  },
   "rootDir": "..",
   "roots": ["<rootDir>/test"],
   "testEnvironment": "node",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,6 @@
     "target": "es2017",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
     "incremental": true
   },
   "include": ["src", "test"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -11770,6 +11770,7 @@ nestjs-graphql-dataloader@^0.1.28:
     reflect-metadata: ^0.1.13
     rimraf: ^3.0.2
     rxjs: ^6.6.3
+    src: "link:src"
     supertest: ^5.0.0
     transliteration: ^2.1.11
     ts-jest: 26.4.1
@@ -12705,6 +12706,12 @@ nestjs-graphql-dataloader@^0.1.28:
   checksum: 51df1bce9e577287f56822d79ac5bd94f6c634fccf193895f2a1d2db2e975b6aa7bc97afae9cf11d49b7c37fe4afc188ff5c4878be91f2c86eabd11c5df8b62c
   languageName: node
   linkType: hard
+
+"src@link:src::locator=registree-core%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "src@link:src::locator=registree-core%40workspace%3A."
+  languageName: node
+  linkType: soft
 
 "sshpk@npm:^1.7.0":
   version: 1.16.1


### PR DESCRIPTION
1. Use Yarn 2 link protocol for `src` package. This simplifies module name resolution situation a bit, and removes the need for **moduleNameMapper** in the Jest configs. ([Yarn 2 docs](https://yarnpkg.com/features/protocols#why-is-the-link-protocol-recommended-over-aliases-for-path-mapping))

2. Add missing Jest **testRegex** escapes for `.`. Without this, the base Jest config's pattern (`.spec.ts$`) matches `*.e2e-spec.ts` too.

3. Remove tsconfig **baseUrl** (no longer needed).

4. Change Jest **rootDir** from `src` to `.`, and add `test` as **root**. This allows Jest to find non-E2E tests under the `test` directory too.

(I pulled these changes and fixes out of the work in progress for #363: they're general maintenance that's easier to review separately.)