### PR TITLE
chore(deps): update ssri 8.0.0 → 8.0.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12084,11 +12084,11 @@ nestjs-graphql-dataloader@^0.1.28:
   linkType: hard
 
 "ssri@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "ssri@npm:8.0.0"
+  version: 8.0.1
+  resolution: "ssri@npm:8.0.1"
   dependencies:
     minipass: ^3.1.1
-  checksum: 97964745a80846b4a50d4506b10b08d35384c3cec482d687cae5f4b7c842afe239c8c368d620f5d7d92642ab75379b409aa809072c2b8e94ec15d9c70d843da5
+  checksum: d45f9a1d5676f8ebd888a3ae469772d75858e4095087217c2361a6b07a6eefd5a85350bb0fed63128b0025fdf242e81813be0979e6cb956a38dbf26295dca09c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is a security update for CVE-2021-27290, Regular Expression Denial of Service (ReDoS):

> ssri 5.2.2-8.0.0, fixed in 8.0.1, processes SRIs using a regular
expression which is vulnerable to a denial of service. Malicious SRIs
could take an extremely long time to process, leading to denial of
service. This issue only affects consumers using the strict option.

 * https://github.com/advisories/GHSA-vx3p-948g-6vhq