### PR TITLE
chore(deps): security update glob-parent 5.1.1 → 5.1.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6767,11 +6767,11 @@ __metadata:
   linkType: hard
 
 "glob-parent@npm:^5.0.0, glob-parent@npm:^5.1.0, glob-parent@npm:~5.1.0":
-  version: 5.1.1
-  resolution: "glob-parent@npm:5.1.1"
+  version: 5.1.2
+  resolution: "glob-parent@npm:5.1.2"
   dependencies:
     is-glob: ^4.0.1
-  checksum: 2af6e196fba4071fb07ba261366e446ba2b320e6db0a2069cf8e12117c5811abc6721f08546148048882d01120df47e56aa5a965517a6e5ba19bfeb792655119
+  checksum: 82fcaa4ce102a0ae01370ed8fd5299ca32184af0418e1c1b613ed851240160558c0cc9712868eb9ca1924f687b07cd9c70c25f303f39f9f376d9a32f94f28e76
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes:

* https://github.com/advisories/GHSA-ww39-953v-wcq6
* https://nvd.nist.gov/vuln/detail/CVE-2020-28469
* https://github.com/gulpjs/glob-parent/pull/36