### PR TITLE
chore(deps): security update tar 6.1.6 → 6.1.11

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12486,8 +12486,8 @@ resolve@^1.20.0:
   linkType: hard
 
 "tar@npm:^6.0.1, tar@npm:^6.0.2":
-  version: 6.1.6
-  resolution: "tar@npm:6.1.6"
+  version: 6.1.11
+  resolution: "tar@npm:6.1.11"
   dependencies:
     chownr: ^2.0.0
     fs-minipass: ^2.0.0
@@ -12495,7 +12495,7 @@ resolve@^1.20.0:
     minizlib: ^2.1.1
     mkdirp: ^1.0.3
     yallist: ^4.0.0
-  checksum: 45b87c0026e639b7eca2c318c934a4376c6adc6f39c5c4dc9ee8fb7a09b95515b22432c57438dc6b6a621410a06f1789a6bfb5151217a43f0db64f4fb5e99d24
+  checksum: f6cd9b0d7cfc2d715f28aa9911d244d91762dd905079988b1d549ea2c147281d7c9ab4adb590535665a80d5478518a0a8e8b7a9295b81043a9a1c180684f3a25
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This fixes:

* CVE-2021-37701, https://github.com/advisories/GHSA-9r2w-394v-53qc
* CVE-2021-37712, https://github.com/advisories/GHSA-qq89-hq3f-393p
* CVE-2021-37713, https://github.com/advisories/GHSA-5955-9wpr-37jh