### PR TITLE
ci(circleci): fix codecov uploads: update orb 1.1.2 → 3.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   node: circleci/node@4.1.0
   docker: circleci/docker@1.2.1
   kube-orb: circleci/kubernetes@0.11.0
-  codecov: codecov/codecov@1.1.2
+  codecov: codecov/codecov@3.2.0
 
 commands:
   # The circleci/node orb doesn't support Yarn 2 natively yet.


### PR DESCRIPTION
I investigated why the coverage reporting for #357 did not reflect updates, and looking at the CircleCI logs, it seems like the coverage uploads have been silently failing, with the following output:

```
-> Reports have been successfully queued for processing at https://codecov.io/github/registreerocks/registree-core/commit/782939594be9c82d3de981b7810df0f1f153d65c
/bin/bash: line 2: -f: command not found
Codecov upload failed
```

Upgrading the CircleCI Codecov orb seems to fix it, so I'm guessing that the old CircleCI orb's upload mechanism is no longer fully supported.