### PR TITLE
ci: use Node 16 LTS for CirceCI, and Yarn 2 updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,11 +41,12 @@ commands:
       - run:
           command: 'wget https://github.com/mikefarah/yq/releases/download/v4.13.5/yq_linux_amd64 -O /usr/bin/yq && chmod +x /usr/bin/yq'
 
+# XXX(Pi): The cimg/node image only supports major.minor version tags, not major-only.
+#          Issue: Docker image aliases for major version #130 <https://github.com/CircleCI-Public/cimg-node/issues/130>
 jobs:
   test:
-    executor:
-      name: node/default
-      tag: current
+    docker:
+      - image: cimg/node:16.13
     steps:
       - checkout
       - install-packages-yarn-2
@@ -58,7 +59,7 @@ jobs:
 
   test-e2e:
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.13
       - image: circleci/mongo
     environment:
       TEST_MONGO_URI: mongodb://localhost/registree-core-test-WORKER
@@ -85,9 +86,8 @@ jobs:
             /app/doctl apps update --wait $STAGING_APP_ID --spec=updated_spec.yaml
 
   build:
-    executor:
-      name: node/default
-      tag: current
+    docker:
+      - image: cimg/node:16.13
     steps:
       - checkout
       - install-packages-yarn-2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
-  node: circleci/node@4.1.0
+  # Docs: https://circleci.com/developer/orbs/orb/circleci/node
+  node: circleci/node@4.7.0
   docker: circleci/docker@1.7.0
   kube-orb: circleci/kubernetes@0.11.0
   codecov: codecov/codecov@3.2.0
@@ -15,19 +16,9 @@ commands:
     steps:
       # Reference: https://circleci.com/developer/orbs/orb/circleci/node#commands-install-packages
       - node/install-packages:
-          pkg-manager: yarn
-
-          # Yarn 1 default: "yarn install --frozen-lockfile"
-          # Yarn 2 deprecates "--frozen-lockfile" in favour of "--immutable"
-          override-ci-command: yarn install --immutable
-
-          # Yarn 1 default: "node_modules"
-          # Yarn 2 uses ".yarn/cache" instead
-          cache-path: .yarn/cache
+          pkg-manager: yarn-berry
 
           # Disable this while the orb lacks more useful partial cache keys.
-          #
-          # Upstream bug: https://github.com/CircleCI-Public/node-orb/issues/63
           #
           # (The current behaviour is to prefix the with the branch name,
           # which effectively clears the cache for every new branch.)


### PR DESCRIPTION
- fix Node versions to 16 (LTS), rather than 17
- update circleci/node orb, and use new yarn-berry support 